### PR TITLE
Improve test isolation and mocking

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from qwen_assistant.security import api_keys, auth, data_protection, logging as sec_logging, security_manager
+
+@pytest.fixture(autouse=True)
+def reset_singletons(monkeypatch):
+    """Reset singleton caches between tests for isolation."""
+    # clear lru_cache on get_api_key_manager
+    try:
+        api_keys.get_api_key_manager.cache_clear()
+    except AttributeError:
+        pass
+    monkeypatch.setattr(auth, "_auth_instance", None, raising=False)
+    monkeypatch.setattr(data_protection, "_data_protection_instance", None, raising=False)
+    monkeypatch.setattr(sec_logging, "_security_logger", None, raising=False)
+    monkeypatch.setattr(security_manager, "_security_manager", None, raising=False)
+    yield

--- a/tests/test_desktop_agent.py
+++ b/tests/test_desktop_agent.py
@@ -2,10 +2,7 @@
 Tests for the Desktop Agent implementation.
 """
 import pytest
-import pytest_asyncio
-import asyncio
-from unittest.mock import patch, AsyncMock, MagicMock
-import json
+from unittest.mock import patch, AsyncMock
 
 from qwen_assistant.agents.desktop import DesktopAgent
 
@@ -35,6 +32,14 @@ def desktop_agent(desktop_agent_config, model_config):
     """Create a desktop agent for testing."""
     agent = DesktopAgent(desktop_agent_config, model_config)
     return agent
+
+
+@pytest.fixture
+def mock_mcp(monkeypatch):
+    """Patch DesktopAgent._mcp_call to avoid network access."""
+    async_mock = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(DesktopAgent, "_mcp_call", async_mock)
+    return async_mock
 
 
 class TestDesktopAgent:
@@ -73,46 +78,62 @@ class TestDesktopAgent:
         assert confidence == expected_confidence
 
     @pytest.mark.asyncio
-    async def test_handle_request_execute_command(self, desktop_agent):
+    async def test_execute_command_calls_mcp(self, desktop_agent, mock_mcp):
+        result = await desktop_agent.execute_command("ls")
+        mock_mcp.assert_called_once_with("execute_command", {"command": "ls"})
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_read_file_calls_mcp(self, desktop_agent, mock_mcp):
+        result = await desktop_agent.read_file("foo.txt")
+        mock_mcp.assert_called_once_with("read_file", {"path": "foo.txt"})
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_handle_request_execute_command(self, desktop_agent, mock_mcp):
         """Test handling execute command request."""
-        with patch.object(desktop_agent, "execute_command", new_callable=AsyncMock) as mock_execute:
-            mock_execute.return_value = {"success": True, "output": "command output"}
-            
-            request = {"query": "run ls -la", "action": "execute_command", "command": "ls -la"}
-            context = {}
-            
-            response = await desktop_agent.handle_request(request, context)
-            
-            assert response["success"] is True
-            assert response["agent"] == "DesktopAgent"
-            assert "Executed command" in response["message"]
-            mock_execute.assert_called_once_with("ls -la")
+        request = {"query": "run ls -la", "action": "execute_command", "command": "ls -la"}
+        context = {}
+
+        response = await desktop_agent.handle_request(request, context)
+
+        assert response["success"] is True
+        assert response["agent"] == "DesktopAgent"
+        assert "Executed command" in response["message"]
+        mock_mcp.assert_called_once_with("execute_command", {"command": "ls -la"})
 
     @pytest.mark.asyncio
-    async def test_handle_request_read_file(self, desktop_agent):
+    async def test_handle_request_read_file(self, desktop_agent, mock_mcp):
         """Test handling read file request."""
-        with patch.object(desktop_agent, "read_file", new_callable=AsyncMock) as mock_read:
-            mock_read.return_value = {"success": True, "content": "file content"}
-            
-            request = {"query": "read file.txt", "action": "read_file", "file_path": "file.txt"}
-            context = {}
-            
-            response = await desktop_agent.handle_request(request, context)
-            
-            assert response["success"] is True
-            assert "Read file" in response["message"]
-            mock_read.assert_called_once_with("file.txt")
+        request = {"query": "read file.txt", "action": "read_file", "file_path": "file.txt"}
+        context = {}
+
+        response = await desktop_agent.handle_request(request, context)
+
+        assert response["success"] is True
+        assert "Read file" in response["message"]
+        mock_mcp.assert_called_once_with("read_file", {"path": "file.txt"})
 
     @pytest.mark.asyncio
-    async def test_mcp_call(self, desktop_agent):
-        """Test MCP API call."""
-        with patch("aiohttp.ClientSession.post") as mock_post:
-            mock_response = AsyncMock()
-            mock_response.json.return_value = {"success": True, "result": "test result"}
-            mock_post.return_value.__aenter__.return_value = mock_response
-            
-            result = await desktop_agent._mcp_call("test_tool", {"param": "value"})
-            
-            assert result["success"] is True
-            assert result["result"] == "test result"
-            mock_post.assert_called_once()
+    async def test_mcp_call(self, desktop_agent, monkeypatch):
+        """Test MCP API call without real network access."""
+
+        async def fake_post(self, url, json):
+            class FakeResp:
+                async def __aenter__(self_inner):
+                    return self_inner
+
+                async def __aexit__(self_inner, exc_type, exc, tb):
+                    pass
+
+                async def json(self_inner):
+                    return {"success": True, "result": "test result"}
+
+            return FakeResp()
+
+        monkeypatch.setattr("aiohttp.ClientSession.post", fake_post)
+
+        result = await desktop_agent._mcp_call("test_tool", {"param": "value"})
+
+        assert result["success"] is True
+        assert result["result"] == "test result"


### PR DESCRIPTION
## Summary
- add `conftest.py` to reset security singletons between tests
- refactor `test_desktop_agent.py`
  - provide fixture that mocks `_mcp_call`
  - restructure async tests to use the fixture
  - avoid real network calls with a lightweight stub
  - add direct tests for `execute_command` and `read_file`

## Testing
- `pytest -q` *(fails: command not found)*